### PR TITLE
Chat: Fix send button by adding proper event listener

### DIFF
--- a/Chat/index.html
+++ b/Chat/index.html
@@ -64,7 +64,7 @@
     <div class="input-container">
         <button id="sendButton">Rec</button>
         <input type="text" id="userInput" class="input-field" placeholder="Type a message...">
-        <button class="send-button" onclick="send_message()">Send</button>
+        <button class="send-button" id="sendMessageButton" >Send</button>
     </div>
   </div>
 
@@ -327,6 +327,8 @@
           send_message();
       }
   })
+  // listener for send message button click
+  document.getElementById("sendMessageButton").addEventListener("click", send_message);
 
   // get openai API key (use this in API calls)
   function get_openai_api_key() {


### PR DESCRIPTION
clicking on the send button for the chat interface was displaying the "send_message is not defined" error.
The issue is that The `send_message()` function is defined inside a script with `type="module"` which makes it unavailable by default in the global scope.
To fix it, I just created an event listener is within the same module scope as `send_message()`.